### PR TITLE
Cleanup JupyterHub Dockerfile

### DIFF
--- a/components/jupyterhub/docker/Dockerfile
+++ b/components/jupyterhub/docker/Dockerfile
@@ -21,10 +21,11 @@ RUN npm install -g configurable-http-proxy && \
     pip3 install --upgrade pip && \
     pip3 install --upgrade setuptools && \
     pip3 install --upgrade disttools && \
-    pip3 install jupyterhub-dummyauthenticator && \
-    pip3 install oauthenticator && \
-    pip3 install notebook && \
-    pip3 install jupyterhub==0.8.1 && \
-    pip3 install jupyterhub-kubespawner==0.7.1
+    pip3 install --no-cache-dir \
+                 notebook \
+                 jupyterhub==0.8.1 \
+                 jupyterhub-kubespawner==0.7.1 \
+                 jupyterhub-dummyauthenticator \
+                 oauthenticator
 
 ENTRYPOINT jupyterhub

--- a/components/jupyterhub/docker/Dockerfile
+++ b/components/jupyterhub/docker/Dockerfile
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.5
+FROM python:3.6
 
 RUN apt-get update && \
     apt-get install -y npm nodejs-legacy
 
 RUN npm install -g configurable-http-proxy && \
-    pip3 install --upgrade pip && \
-    pip3 install --upgrade setuptools && \
-    pip3 install --upgrade disttools && \
     pip3 install --no-cache-dir \
                  notebook \
                  jupyterhub==0.8.1 \


### PR DESCRIPTION
- Bump Python version so we don't need to run pip upgrade
- Don't store wheels cache in dockerfile