### PR TITLE
Enable PVCs for per-user persistent storage

### DIFF
--- a/components/jupyterhub/manifests/config.yaml
+++ b/components/jupyterhub/manifests/config.yaml
@@ -103,6 +103,22 @@ data:
     c.KubeSpawner.user_storage_pvc_ensure = True
     # How much disk space do we want?
     c.KubeSpawner.user_storage_capacity = '10Gi'
+    c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
+    c.KubeSpawner.volumes = [
+        {
+            'name': 'volume-{username}{servername}',
+            'persistentVolumeClaim': {
+                'claimName': 'claim-{username}{servername}'
+            }
+        }
+    ]
+    c.KubeSpawner.volume_mounts = [
+        {
+            # This should point to homedir of the user in the image
+            'mountPath': '/home/jovyan',
+            'name': 'volume-{username}{servername}'
+        }
+    ]
 
 
     ###################################################

--- a/components/jupyterhub/manifests/config.yaml
+++ b/components/jupyterhub/manifests/config.yaml
@@ -98,6 +98,14 @@ data:
     ###################################################
 
     ###################################################
+    ### Persistent volume options
+    ###################################################
+    c.KubeSpawner.user_storage_pvc_ensure = True
+    # How much disk space do we want?
+    c.KubeSpawner.user_storage_capacity = '10Gi'
+
+
+    ###################################################
     ### Authenticator Options
     ###################################################
     c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'


### PR DESCRIPTION
Remember that tearing down a cluster doesn't clean up the PVCs
provisioned, and you have to actually delete the PVCs before
tearing down the cluster manually.

This relies on a default storage provisioner being present
on the k8s cluster. On GKE, this gives you 10Gi of stnadard
non-ssd storage.