### PR TITLE
Add a note about TF serving Deployment not working with Minikube's kvm driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ This documentation assumes you have a Kubernetes cluster already available. For 
 
 [Minikube](https://github.com/kubernetes/minikube) is a tool that makes it easy to run Kubernetes locally. Minikube runs a
 single-node Kubernetes cluster inside a VM on your laptop for users looking to try out Kubernetes or develop with it day-to-day.
+
 The below steps apply to a minikube cluster - the latest version as of writing this documentation is 0.23.0. You must also have
 kubectl configured to access minikube.
+
+Finally, the Virtualbox/VMware drivers for Minikube are recommended as there is a known
+issue between the KVM/KVM2 driver and the TensorFlow Serving deployment, tracked in [kubernetes/minikube#2377](https://github.com/kubernetes/minikube/issues/2377).
 
 ### Google Kubernetes Engine
 


### PR DESCRIPTION
Hi,

First of all, great project, looking forward to it developing further!

I've noticed that the model-server pods are crashing in Minikube with:
```
Illegal instruction (core dumped)
```
(that's the full output). That error message got me to https://github.com/mozilla/DeepSpeech/issues/912 which suggested the CPU's virtualisation might be the problem. And indeed, changing my Minikube's driver from `kvm2` to `virtualbox` fixed it. 

It would be nice for this to work with KVM which in my experience has performed better than virtualbox when under load. In the meantime, here's a PR adding a note about it not working with KVM. It's possible the issue is just on my machine (Intel i7-6700 CPU) so feel free to reject the PR if it's actually working.

