### PR TITLE
fix(doc): correct cli instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ks pkg install kubeflow/tf-job
 
 # Deploy Kubeflow
 ks generate core kubeflow-core --name=kubeflow-core --namespace=${NAMESPACE}
-ks apply default kubeflow-core
+ks apply default -c kubeflow-core
 ```
 
 


### PR DESCRIPTION
When I typed CLI instruction from README:

> ks apply default kubeflow-core

The  errors occured like:

```
$ ks apply default kubeflow-core
ERROR 'apply' requires an environment name; use `env list` to see available environments

Usage:
  ks apply <env-name> [-c <component-name>] [--dry-run] [flags]

Examples:

# Create or update all resources described in the ksonnet application, specifically
# the ones running in the 'dev' environment. This command works in any subdirectory
# of the app.
#
# This essentially deploys all components in the 'components/' directory.
ks apply dev .....
```

This PR fixes misleading instructions on README.
