### PR TITLE
Some improvements to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,6 @@ This documentation assumes you have a Kubernetes cluster already available.
 
 If you need help setting up a Kubernetes cluster please refer to [Kubernetes' Setup](https://kubernetes.io/docs/setup/).
 
-For specific Kubernetes installations, additional configuration may be necessary.
-
-### Minikube
-
-[Minikube](https://github.com/kubernetes/minikube) is a tool that makes it easy to run Kubernetes locally. Minikube runs a
-single-node Kubernetes cluster inside a VM on your laptop for users looking to try out Kubernetes or develop with it day-to-day.
-
-The below steps apply to a minikube cluster - the latest version as of writing this documentation is 0.23.0. You must also have
-kubectl configured to access minikube.
-
-Finally, the Virtualbox/VMware drivers for Minikube are recommended as there is a known
-issue between the KVM/KVM2 driver and the TensorFlow Serving deployment, tracked in [kubernetes/minikube#2377](https://github.com/kubernetes/minikube/issues/2377).
-
-### Google Kubernetes Engine
-
-[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-container-cluster) is a managed environment for deploying Kubernetes applications powered by Google Cloud.
-If you're using Google Kubernetes Engine, prior to creating the manifests, you must grant your own user the requisite RBAC role to create/edit other RBAC roles.
-
-```commandline
-kubectl create clusterrolebinding default-admin --clusterrole=cluster-admin --user=user@gmail.com
-```
 ## Quick Start
 
 Requirements
@@ -79,6 +58,30 @@ Used together, these make it easy for a user go from training to serving using T
 effort in a portable fashion between different environments. 
 
 For more detailed instructions about how to use Kubeflow please refer to the [user guide](user_guide.md)
+
+## Troubleshooting
+
+### Minikube
+
+On [Minikube](https://github.com/kubernetes/minikube) the Virtualbox/VMware drivers for Minikube are recommended as there is a known
+issue between the KVM/KVM2 driver and TensorFlow Serving. The issue is tracked in [kubernetes/minikube#2377](https://github.com/kubernetes/minikube/issues/2377).
+
+### RBAC clusters
+
+If you are running on a K8s cluster with RBAC enabled, you may get an error like the following when deploying Kubeflow: 
+
+```
+ERROR Error updating roles kubeflow-test-infra.jupyter-role: roles.rbac.authorization.k8s.io "jupyter-role" is forbidden: attempt to grant extra privileges: [PolicyRule{Resources:["*"], APIGroups:["*"], Verbs:["*"]}] user=&{your-user@acme.com  [system:authenticated] map[]} ownerrules=[PolicyRule{Resources:["selfsubjectaccessreviews"], APIGroups:["authorization.k8s.io"], Verbs:["create"]} PolicyRule{NonResourceURLs:["/api" "/api/*" "/apis" "/apis/*" "/healthz" "/swagger-2.0.0.pb-v1" "/swagger.json" "/swaggerapi" "/swaggerapi/*" "/version"], Verbs:["get"]}] ruleResolutionErrors=[]
+```
+
+need sufficient permission to be able to create RBAC roles. 
+
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-container-cluster) is a managed environment for deploying Kubernetes applications powered by Google Cloud.
+If you're using Google Kubernetes Engine, prior to creating the manifests, you must grant your own user the requisite RBAC role to create/edit other RBAC roles.
+
+```commandline
+kubectl create clusterrolebinding default-admin --clusterrole=cluster-admin --user=user@gmail.com
+```
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This documentation assumes you have a Kubernetes cluster already available.
 
 If you need help setting up a Kubernetes cluster please refer to [Kubernetes' Setup](https://kubernetes.io/docs/setup/).
 
+If you want to use GPUs be sure to follow the Kubernetes [instructions for enabling GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/).
+
 ## Quick Start
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ Ultimately, we want to have a set of simple manifests that give you an easy to u
 
 ## Setup
 
-This documentation assumes you have a Kubernetes cluster already available. For specific Kubernetes installations, additional configuration may be necessary.
+This documentation assumes you have a Kubernetes cluster already available. 
+
+If you need help setting up a Kubernetes cluster please refer to [Kubernetes' Setup](https://kubernetes.io/docs/setup/).
+
+For specific Kubernetes installations, additional configuration may be necessary.
 
 ### Minikube
 
@@ -36,7 +40,7 @@ issue between the KVM/KVM2 driver and the TensorFlow Serving deployment, tracked
 
 ### Google Kubernetes Engine
 
-[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) is a managed environment for deploying Kubernetes applications powered by Google Cloud.
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-container-cluster) is a managed environment for deploying Kubernetes applications powered by Google Cloud.
 If you're using Google Kubernetes Engine, prior to creating the manifests, you must grant your own user the requisite RBAC role to create/edit other RBAC roles.
 
 ```commandline

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ If you are running on a K8s cluster with RBAC enabled, you may get an error like
 ERROR Error updating roles kubeflow-test-infra.jupyter-role: roles.rbac.authorization.k8s.io "jupyter-role" is forbidden: attempt to grant extra privileges: [PolicyRule{Resources:["*"], APIGroups:["*"], Verbs:["*"]}] user=&{your-user@acme.com  [system:authenticated] map[]} ownerrules=[PolicyRule{Resources:["selfsubjectaccessreviews"], APIGroups:["authorization.k8s.io"], Verbs:["create"]} PolicyRule{NonResourceURLs:["/api" "/api/*" "/apis" "/apis/*" "/healthz" "/swagger-2.0.0.pb-v1" "/swagger.json" "/swaggerapi" "/swaggerapi/*" "/version"], Verbs:["get"]}] ruleResolutionErrors=[]
 ```
 
-need sufficient permission to be able to create RBAC roles. 
-
-[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-container-cluster) is a managed environment for deploying Kubernetes applications powered by Google Cloud.
-If you're using Google Kubernetes Engine, prior to creating the manifests, you must grant your own user the requisite RBAC role to create/edit other RBAC roles.
+This error indicates you do not have sufficient permissions. In many cases you can resolve this just by creating an appropriate
+clusterrole binding like so and then redeploying kubeflow
 
 ```commandline
-kubectl create clusterrolebinding default-admin --clusterrole=cluster-admin --user=user@gmail.com
+kubectl create clusterrolebinding default-admin --clusterrole=cluster-admin --user=your-user@acme.com
 ```
+
+	* Replace `your-user@acme.com` with the user listed in the error message.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ultimately, we want to have a set of simple manifests that give you an easy to u
 
 This documentation assumes you have a Kubernetes cluster already available. 
 
-If you need help setting up a Kubernetes cluster please refer to [Kubernetes' Setup](https://kubernetes.io/docs/setup/).
+If you need help setting up a Kubernetes cluster please refer to [Kubernetes Setup](https://kubernetes.io/docs/setup/).
 
 If you want to use GPUs be sure to follow the Kubernetes [instructions for enabling GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/).
 
@@ -70,7 +70,7 @@ issue between the KVM/KVM2 driver and TensorFlow Serving. The issue is tracked i
 
 ### RBAC clusters
 
-If you are running on a K8s cluster with RBAC enabled, you may get an error like the following when deploying Kubeflow: 
+If you are running on a K8s cluster with [RBAC enabled](https://kubernetes.io/docs/admin/authorization/rbac/#command-line-utilities), you may get an error like the following when deploying Kubeflow: 
 
 ```
 ERROR Error updating roles kubeflow-test-infra.jupyter-role: roles.rbac.authorization.k8s.io "jupyter-role" is forbidden: attempt to grant extra privileges: [PolicyRule{Resources:["*"], APIGroups:["*"], Verbs:["*"]}] user=&{your-user@acme.com  [system:authenticated] map[]} ownerrules=[PolicyRule{Resources:["selfsubjectaccessreviews"], APIGroups:["authorization.k8s.io"], Verbs:["create"]} PolicyRule{NonResourceURLs:["/api" "/api/*" "/apis" "/apis/*" "/healthz" "/swagger-2.0.0.pb-v1" "/swagger.json" "/swaggerapi" "/swaggerapi/*" "/version"], Verbs:["get"]}] ruleResolutionErrors=[]
@@ -84,6 +84,9 @@ kubectl create clusterrolebinding default-admin --clusterrole=cluster-admin --us
 ```
 
 	* Replace `your-user@acme.com` with the user listed in the error message.
+
+If you're using, GKE you may want to refer to [GKE's RBAC docs](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control) to understand
+how RBAC interacts with IAM on GCP.
 
 ## Resources
 

--- a/components/k8s-model-server/README.md
+++ b/components/k8s-model-server/README.md
@@ -62,7 +62,7 @@ Download and install the [Google Cloud SDK](https://cloud.google.com/sdk/downloa
 Use the [gsutil mb](https://cloud.google.com/storage/docs/gsutil/commands/mb) command to create a bucket. Note that 
 the bucket name must be globally unique.
 ```commandline
-gsutil mb gs://<ucket-name>
+gsutil mb gs://<bucket-name>
 ``` 
 
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -54,7 +54,7 @@ If the user is running on a Cloud they could create an environment for this.
 
 ```
 ks env add cloud
-ks param set --cloud=gke
+ks param set --env=cloud kubeflow-core cloud=gke
 ```
    * The cloud parameter triggers a set of curated cloud configs.
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -198,8 +198,7 @@ Set the disks parameter to a comma separated list of the Google persistent disks
   * These disks should be in the same zone as your cluster
   * These disks need to be created manually via gcloud or the Cloud console e.g.
   * These disks can't be attached to any existing VM or POD.
-  * TODO(jlewi): Can we rely on the default storage class to create the backing for store for NFS? Would that be portable across clouds
-    and avoid users having to create the disks manually?
+  
 Create the disks
 
 ```

--- a/user_guide.md
+++ b/user_guide.md
@@ -11,8 +11,6 @@ If you are unfamiliar with ksonnet you may want to start by reading the [tutoria
 
 You need ksonnet version [0.8.0 release](https://github.com/ksonnet/ksonnet/releases) or later.
 
-As of this writing, Heptio hasn't released any newer prebuilt binaries so you will need to [build from source](https://ksonnet.io/docs/build-install).
-
 ## Deploy Kubeflow
 
 Initialize a directory to contain your deployment

--- a/user_guide.md
+++ b/user_guide.md
@@ -4,12 +4,9 @@ If you are unfamiliar with ksonnet you may want to start by reading the [tutoria
 
 ## Requirements
 
-  * ksonnet version [0.8.0](https://github.com/ksonnet/ksonnet/releases) or later.
+  * ksonnet version [0.8.0](https://ksonnet.io/#get-started) or later.
+    * See [below](#why-kubeflow-uses-ksonnet) for an explanation of why we use ksonnet
   * Kubernetes >= 1.8 [see here](https://github.com/tensorflow/k8s#requirements)
-
-## Get ksonnet
-
-You need ksonnet version [0.8.0 release](https://github.com/ksonnet/ksonnet/releases) or later.
 
 ## Deploy Kubeflow
 
@@ -38,8 +35,6 @@ Create the Kubeflow core component. The core component includes
 ks generate core kubeflow-core --name=kubeflow-core --namespace=${NAMESPACE}
 ```
   * namespace is optional
-  * TODO(jlewi): There's an open github [issue](https://github.com/ksonnet/ksonnet/issues/222) to allow components to pull
-    the namespace from the environment namespace parameter.
 
 
 Define an environment that doesn't use any Cloud features
@@ -248,3 +243,16 @@ shm                                                                65536       0
 tmpfs                                                           15444244       0   15444244   0% /sys/firmware
 ```
   * Here `jlewi-kubeflow-test1` and `jlewi-kubeflow-test2` are the names of the PDs.
+
+## Why Kubeflow Uses Ksonnet
+
+[Ksonnet](https://ksonnet.io/) is a command line tool that makes it easier to manage complex deployments consisting of multiple components. It is designed to
+work side by side with kubectl.
+
+Ksonnet allows us to generate Kubernetes manifests from parameterized templates. This makes it easy to customize Kubernetes manifests for your
+particular use case. In the examples above we used this functionality to generate manifests for TfServing with a user supplied URI for the model.
+
+One of the reasons we really like ksonnet is because it treats [environment](https://ksonnet.io/docs/concepts#environment) as in (dev, test, staging, prod) as a first class concept. For each environment we can easily deploy the same components but with slightly different parameters
+to customize it for a particular environments. We think this maps really well to common workflows. For example, this feature makes it really
+easy to run a job locally without GPUs for a small number of steps to make sure the code doesn't crash, and then easily move that to the
+Cloud to run at scale with GPUs.


### PR DESCRIPTION
* Remove note about building ksonnet from source; there is now a released artifact for version 0.8.0

* Remove instructions about setting up K8s clusters; just link to the K8s docs.

* Move notes about minikube and GKE to a troubleshooting section.

* Add info about why ksonnet.
  