### PR TITLE
Updated Quick Start section on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ If you want to use GPUs be sure to follow the Kubernetes [instructions for enabl
 
 ## Quick Start
 
-Requirements
+### Requirements
 
-  * ksonnet version [0.8.0](https://github.com/ksonnet/ksonnet/releases) or later.
+  * ksonnet version [0.8.0](https://github.com/ksonnet/ksonnet) or later.
   * Kubernetes >= 1.8 [see here](https://github.com/tensorflow/k8s#requirements)
+
+### Steps
 
 In order to quickly set up all components, execute the following commands,
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you want to use GPUs be sure to follow the Kubernetes [instructions for enabl
 
 ### Requirements
 
-  * ksonnet version [0.8.0](https://github.com/ksonnet/ksonnet) or later.
+  * ksonnet version [0.8.0](https://ksonnet.io/#get-started) or later.
   * Kubernetes >= 1.8 [see here](https://github.com/tensorflow/k8s#requirements)
 
 ### Steps


### PR DESCRIPTION
In response to [Issue 91](https://github.com/google/kubeflow/issues/91),
raised by @sebgoa.

Although I was the one who had originally complained about the ksonnet
installation, I think the problem has been solved by not asking the user
to manually install it from source anymore and it's okay to point at the
top-level of the ksonnet documentation rather than the release page.