### PR TITLE
fix #107; args improperly set to the namespace

### DIFF
--- a/kubeflow/tf-job/prototypes/tf-job.jsonnet
+++ b/kubeflow/tf-job/prototypes/tf-job.jsonnet
@@ -23,7 +23,7 @@ local tfJob = import 'kubeflow/tf-job/tf-job.libsonnet';
 local name = import 'param://name';
 local namespace = import 'param://namespace';
 
-local argsParam = import 'param://namespace';
+local argsParam = import 'param://args';
 local args = 
     if argsParam == "null" then
     []


### PR DESCRIPTION
* Args for TfJob should be set to the args parameter and not the namespace parameter.
* Fix https://github.com/google/kubeflow/issues/107
  