### PR TITLE
update tf-cnn example use terminationPolicy to address not using master replica

### DIFF
--- a/tf-controller-examples/tf-cnn/launcher.py
+++ b/tf-controller-examples/tf-cnn/launcher.py
@@ -75,16 +75,6 @@ if __name__ == "__main__":
   command.append("--worker_hosts=" + worker_hosts)
   command.append("--task_index={0}".format(task_index))
 
-  # TODO(jlewi): This is a work around
-  # https://github.com/tensorflow/k8s/issues/192
-  # Since TfJob requires a master but the tf benchmark
-  # code doesn't know what to do with master we just run
-  # forever in the master.
-  if job_name.lower() == "master":
-    while True:
-      print("master runs forever.")
-      time.sleep(600)
-
   logging.info("Command to run: %s", " ".join(command))
   with open("/opt/run_benchmarks.sh", "w") as hf:
     hf.write("#!/bin/bash\n")

--- a/tf-controller-examples/tf-cnn/tf_job_cpu.yaml
+++ b/tf-controller-examples/tf-cnn/tf_job_cpu.yaml
@@ -38,26 +38,6 @@ spec:
           name: tensorflow
           workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
         restartPolicy: OnFailure
-    tfReplicaType: MASTER
-  - replicas: 1
-    template:
-      spec:
-        containers:
-        - args:
-          - python
-          - tf_cnn_benchmarks.py
-          - --batch_size=32
-          - --model=resnet50
-          - --variable_update=parameter_server
-          - --flush_stdout=true
-          - --num_gpus=1
-          - --local_parameter_device=cpu
-          - --device=cpu
-          - --data_format=NHWC
-          image: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3
-          name: tensorflow
-          workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
-        restartPolicy: OnFailure
     tfReplicaType: WORKER
   - replicas: 1
     template:
@@ -79,4 +59,8 @@ spec:
           workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
         restartPolicy: OnFailure
     tfReplicaType: PS
+  terminationPolicy:
+    chief:
+      replicaName: WORKER
+      replicaIndex: 0
   tfImage: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3

--- a/tf-controller-examples/tf-cnn/tf_job_cpu_distributed.yaml
+++ b/tf-controller-examples/tf-cnn/tf_job_cpu_distributed.yaml
@@ -19,26 +19,6 @@ metadata:
   namespace: default
 spec:
   replicaSpecs:
-  - replicas: 1
-    template:
-      spec:
-        containers:
-        - args:
-          - python
-          - tf_cnn_benchmarks.py
-          - --batch_size=32
-          - --model=resnet50
-          - --variable_update=parameter_server
-          - --flush_stdout=true
-          - --num_gpus=1
-          - --local_parameter_device=cpu
-          - --device=cpu
-          - --data_format=NHWC
-          image: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3
-          name: tensorflow
-          workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
-        restartPolicy: OnFailure
-    tfReplicaType: MASTER
   - replicas: 3
     template:
       spec:
@@ -79,4 +59,8 @@ spec:
           workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
         restartPolicy: OnFailure
     tfReplicaType: PS
+  terminationPolicy:
+    chief:
+      replicaName: WORKER
+      replicaIndex: 0
   tfImage: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3

--- a/tf-controller-examples/tf-cnn/tf_job_gpu.yaml
+++ b/tf-controller-examples/tf-cnn/tf_job_gpu.yaml
@@ -31,23 +31,6 @@ spec:
           - --variable_update=parameter_server
           - --flush_stdout=true
           - --num_gpus=1
-          image: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3
-          name: tensorflow
-          workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
-        restartPolicy: OnFailure
-    tfReplicaType: MASTER
-  - replicas: 1
-    template:
-      spec:
-        containers:
-        - args:
-          - python
-          - tf_cnn_benchmarks.py
-          - --batch_size=32
-          - --model=resnet50
-          - --variable_update=parameter_server
-          - --flush_stdout=true
-          - --num_gpus=1
           image: gcr.io/kubeflow/tf-benchmarks-gpu:v20171202-bdab599-dirty-284af3
           name: tensorflow
           resources:
@@ -73,4 +56,8 @@ spec:
           workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
         restartPolicy: OnFailure
     tfReplicaType: PS
+  terminationPolicy:
+    chief:
+      replicaName: WORKER
+      replicaIndex: 0
   tfImage: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3

--- a/tf-controller-examples/tf-cnn/tf_job_gpu_distributed.yaml
+++ b/tf-controller-examples/tf-cnn/tf_job_gpu_distributed.yaml
@@ -19,23 +19,6 @@ metadata:
   namespace: default
 spec:
   replicaSpecs:
-  - replicas: 1
-    template:
-      spec:
-        containers:
-        - args:
-          - python
-          - tf_cnn_benchmarks.py
-          - --batch_size=32
-          - --model=resnet50
-          - --variable_update=parameter_server
-          - --flush_stdout=true
-          - --num_gpus=1
-          image: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3
-          name: tensorflow
-          workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
-        restartPolicy: OnFailure
-    tfReplicaType: MASTER
   - replicas: 3
     template:
       spec:
@@ -73,4 +56,8 @@ spec:
           workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
         restartPolicy: OnFailure
     tfReplicaType: PS
+  terminationPolicy:
+    chief:
+      replicaName: WORKER
+      replicaIndex: 0
   tfImage: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3


### PR DESCRIPTION
* Related to #192 
* Now that terminationPolicy can be used to specify a non-master chief, we no longer need to add a master to run the tf-cnn we can just use worker 0 as the chief which allows the example to run out of the box.