### PR TITLE
Fix TfJob operator roles and TfCNN prototype

### DIFF
--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -71,9 +71,14 @@ std.prune(k.core.v1.list.new([
     tfjob.parts(namespace).tfJobDeploy(tfJobImage), 
     tfjob.parts(namespace).configMap(cloud, tfDefaultImage),
     tfjob.parts(namespace).serviceAccount,
+    tfjob.parts(namespace).operatorRole,
+    tfjob.parts(namespace).operatorRoleBinding,
 
     // TfJob controll ui
-    tfjob.parts(namespace).ui(tfJobImage),     
-    tfjob.parts(namespace).uiService(tfJobUiServiceType),   
+    tfjob.parts(namespace).ui(tfJobImage),
+    tfjob.parts(namespace).uiService(tfJobUiServiceType),
+    tfjob.parts(namespace).uiServiceAccount,
+    tfjob.parts(namespace).uiRole,
+    tfjob.parts(namespace).uiRoleBinding,
 ] + nfsComponents))
 

--- a/kubeflow/core/tf-job.libsonnet
+++ b/kubeflow/core/tf-job.libsonnet
@@ -132,6 +132,114 @@
       }
     },
 
+    operatorRole: {
+      "apiVersion": "rbac.authorization.k8s.io/v1beta1", 
+      "kind": "ClusterRole", 
+      "metadata": {
+        "labels": {
+          "app": "tf-job-operator"
+        }, 
+        "name": "tf-job-operator"
+      }, 
+      "rules": [
+        {
+          "apiGroups": [
+            "tensorflow.org"
+          ], 
+          "resources": [
+            "tfjobs"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }, 
+        {
+          "apiGroups": [
+            "apiextensions.k8s.io"
+          ], 
+          "resources": [
+            "customresourcedefinitions"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }, 
+        {
+          "apiGroups": [
+            "storage.k8s.io"
+          ], 
+          "resources": [
+            "storageclasses"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }, 
+        {
+          "apiGroups": [
+            "batch"
+          ], 
+          "resources": [
+            "jobs"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }, 
+        {
+          "apiGroups": [
+            ""
+          ], 
+          "resources": [
+            "configmaps", 
+            "pods", 
+            "services", 
+            "endpoints", 
+            "persistentvolumeclaims", 
+            "events"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }, 
+        {
+          "apiGroups": [
+            "apps", 
+            "extensions"
+          ], 
+          "resources": [
+            "deployments"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    }, // operator-role
+
+    operatorRoleBinding:: {
+      "apiVersion": "rbac.authorization.k8s.io/v1beta1", 
+      "kind": "ClusterRoleBinding", 
+      "metadata": {
+        "labels": {
+          "app": "tf-job-operator"
+        }, 
+        "name": "tf-job-operator"
+      }, 
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io", 
+        "kind": "ClusterRole", 
+        "name": "tf-job-operator"
+      }, 
+      "subjects": [
+        {
+          "kind": "ServiceAccount", 
+          "name": "tf-job-operator", 
+          "namespace": namespace,
+        }
+      ]
+    }, // operator-role binding
+
     uiService(serviceType):: {
       "apiVersion": "v1", 
       "kind": "Service", 
@@ -152,6 +260,18 @@
         "type": serviceType,
       }
     }, // uiService
+
+    uiServiceAccount: {
+      "apiVersion": "v1", 
+      "kind": "ServiceAccount", 
+      "metadata": {
+        "labels": {
+          "app": "tf-job-dashboard"
+        }, 
+        "name": "tf-job-dashboard",
+        "namespace": namespace,
+      }
+    }, // uiServiceAccount
 
     ui(image):: {
       "apiVersion": "extensions/v1beta1", 
@@ -181,11 +301,119 @@
                   }
                 ]
               }
-            ]
+            ],
+            "serviceAccountName": "tf-job-dashboard", 
           }
         }
       },
     }, // ui
 
+    uiRole:: {
+      "apiVersion": "rbac.authorization.k8s.io/v1beta1", 
+      "kind": "ClusterRole", 
+      "metadata": {
+        "labels": {
+          "app": "tf-job-dashboard"
+        }, 
+        "name": "tf-job-dashboard"
+      }, 
+      "rules": [
+        {
+          "apiGroups": [
+            "tensorflow.org"
+          ], 
+          "resources": [
+            "tfjobs"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }, 
+        {
+          "apiGroups": [
+            "apiextensions.k8s.io"
+          ], 
+          "resources": [
+            "customresourcedefinitions"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }, 
+        {
+          "apiGroups": [
+            "storage.k8s.io"
+          ], 
+          "resources": [
+            "storageclasses"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }, 
+        {
+          "apiGroups": [
+            "batch"
+          ], 
+          "resources": [
+            "jobs"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }, 
+        {
+          "apiGroups": [
+            ""
+          ], 
+          "resources": [
+            "configmaps", 
+            "pods", 
+            "services", 
+            "endpoints", 
+            "persistentvolumeclaims", 
+            "events"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }, 
+        {
+          "apiGroups": [
+            "apps", 
+            "extensions"
+          ], 
+          "resources": [
+            "deployments"
+          ], 
+          "verbs": [
+            "*"
+          ]
+        }
+      ]
+    }, // uiRole 
+
+    uiRoleBinding:: {
+      "apiVersion": "rbac.authorization.k8s.io/v1beta1", 
+      "kind": "ClusterRoleBinding", 
+      "metadata": {
+        "labels": {
+          "app": "tf-job-dashboard"
+        }, 
+        "name": "tf-job-dashboard"
+      }, 
+      "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io", 
+        "kind": "ClusterRole", 
+        "name": "tf-job-dashboard"
+      }, 
+      "subjects": [
+        {
+          "kind": "ServiceAccount", 
+          "name": "tf-job-dashboard", 
+          "namespace": namespace,
+        }
+      ]
+    }, // uiRoleBinding
   },
 }

--- a/kubeflow/tf-job/prototypes/tf-cnn-benchmarks.jsonnet
+++ b/kubeflow/tf-job/prototypes/tf-cnn-benchmarks.jsonnet
@@ -92,8 +92,9 @@ local job =
 	error "num_ps must be >= 1"
 	else
 	tfJob.parts.tfJob(name, namespace, replicas) + {
-							tfImage: image,
-							terminationPolicy: {chief:{replicaName: "WORKER", replicaIndex: 0 }}
-							};
+    spec+: {
+				tfImage: image,
+				terminationPolicy: {chief:{replicaName: "WORKER", replicaIndex: 0 }}
+		}};
 
 std.prune(k.core.v1.list.new([job]))

--- a/testing/test-infra/debug_pod.yaml
+++ b/testing/test-infra/debug_pod.yaml
@@ -1,0 +1,31 @@
+# This pod is useful for starting a shell that you can use to interactively debug our tests
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-job
+  namespace: kubeflow-test-infra
+spec:
+  template:
+    spec:
+      containers:
+      - name: test-container
+        image: gcr.io/mlkube-testing/kubeflow-testing:latest
+        command: ["tail", "-f", "/dev/null"]
+        volumeMounts:
+          - mountPath: /mnt/test-data-volume
+            name: kubeflow-test-volume
+          - mountPath: /secret/gcp-credentials
+            name: gcp-credentials
+        env:        
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /secret/gcp-credentials/key.json
+      restartPolicy: Never
+      volumes:      
+        - name: kubeflow-test-volume
+          persistentVolumeClaim:
+            claimName: kubeflow-testing
+        - name: gcp-credentials
+          secret:
+            secretName: kubeflow-testing-credentials
+
+  backoffLimit: 4

--- a/testing/test_deploy.py
+++ b/testing/test_deploy.py
@@ -129,7 +129,7 @@ def setup(args):
     # its credentials; maybe we need to configure credentials after calling
     # ks init?
     if args.cluster:
-      util.configure_kubectl(args.project, args.zone, args.cluster_name)
+      util.configure_kubectl(args.project, args.zone, args.cluster)
 
     # Sleep for ever so we can ssh in and try to run the command manually.
     #logging.error("DO NOT SUBMIT sleep forever")

--- a/testing/test_deploy.py
+++ b/testing/test_deploy.py
@@ -131,18 +131,8 @@ def setup(args):
     if args.cluster:
       util.configure_kubectl(args.project, args.zone, args.cluster)
 
-    # Sleep for ever so we can ssh in and try to run the command manually.
-    #logging.error("DO NOT SUBMIT sleep forever")
-    #while True:
-      #import time
-      #logging.error("DO NOT SUBMIT sleep forever")
-      #time.sleep(600)
     apply_command = ["ks", "apply", "default", "-c", "kubeflow-core",]
 
-    #if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
-      #with open(os.getenv("GOOGLE_APPLICATION_CREDENTIALS")) as hf:
-        #key = json.load(hf)
-        #apply_command.append("--as=" + key["client_email"])
     util.run(apply_command, cwd=app_dir)
 
     # Verify that the TfJob operator is actually deployed.

--- a/testing/test_deploy.py
+++ b/testing/test_deploy.py
@@ -43,7 +43,8 @@ def _setup_test(api_client, run_label):
 
   try:
     logging.info("Creating namespace %s", namespace.metadata.name)
-    api.create_namespace(namespace)
+    namespace = api.create_namespace(namespace)
+    logging.info("Namespace %s created.", namespace.metadata.name)
   except rest.ApiException as e:
     if e.status == 409:
       logging.info("Namespace %s already exists.", namespace.metadata.name)

--- a/testing/test_deploy.py
+++ b/testing/test_deploy.py
@@ -125,6 +125,12 @@ def setup(args):
     util.run(["ks", "generate", "core", "kubeflow-core", "--name=kubeflow-core",
               "--namespace=" + namespace.metadata.name], cwd=app_dir)
 
+    # Sleep for ever so we can ssh in and try to run the command manually.
+    logging.error("DO NOT SUBMIT sleep forever")
+    while True:
+      import time
+      logging.error("DO NOT SUBMIT sleep forever")
+      time.sleep(600)
     apply_command = ["ks", "apply", "default", "-c", "kubeflow-core",]
 
     if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):

--- a/testing/test_deploy.py
+++ b/testing/test_deploy.py
@@ -147,7 +147,8 @@ def setup(args):
     teardown = test_util.TestCase(main_case.class_name, "teardown")
     def run_teardown():
       core_api = k8s_client.CoreV1Api(api_client)
-      core_api.delete_namespace(namespace_name, {})
+      # core_api.delete_namespace(namespace_name, {})
+      logging.error("DO NOT SUBMIT skipping teardown.")
 
     try:
       test_util.wrap_test(run_teardown, teardown)


### PR DESCRIPTION
* Fix the TFCNN prototype; the termination policy wasn't being properly set

* Create service accounts and role bindings for the TfJob operator and UI

* Fix #129 

* Fix #125

* Fix #95; presubmits/postsubmits need to use the code at the commit we checked out
    * We do this by replacing the directory in vendor with a symbolic link to where we checked out the source.
    * It looks like using "--as" with ksonnet leads to strange errors about the server not being able to create the config map
    * If we don't use "--as" need to fetch credentials a second time or else we get RBAC issues creating the cluster