### PR TITLE
Make Argo UI available publicly at testing-argo.kubeflow.ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [Prow test dashboard](https://k8s-testgrid.appspot.com/sig-big-data)
 [Prow jobs dashboard](https://prow.k8s.io/?repo=google%2Fkubeflow)
+[Argo UI for E2E tests](http://testing-argo.kubeflow.io)
 
 The Kubeflow project is dedicated to making Machine Learning on Kubernetes easy, portable and scalable. Our goal is **not** to recreate other services, but to provide a straightforward way for spinning up best of breed OSS solutions. Contained in this repository are manifests for creating:
 

--- a/testing/test-infra/components/argo.jsonnet
+++ b/testing/test-infra/components/argo.jsonnet
@@ -9,6 +9,7 @@ std.prune(k.core.v1.list.new([argo.parts(namespace).crd,
 							  argo.parts(namespace).deploy,
 							  argo.parts(namespace).deployUi,
 	                          argo.parts(namespace).uiService,
+	                          argo.parts(namespace).uiIngress,
 	                          argo.parts(namespace).serviceAccount,
 	                          argo.parts(namespace).roleBinding,
 	                          argo.parts(namespace).defaultRoleBinding,]))

--- a/testing/test-infra/components/argo.libsonnet
+++ b/testing/test-infra/components/argo.libsonnet
@@ -171,12 +171,47 @@
                     "securityContext": {},
                     "serviceAccount": "argo",
                     "serviceAccountName": "argo",
-                    "terminationGracePeriodSeconds": 30
+                    "terminationGracePeriodSeconds": 30,
+                    "readinessProbe": {
+                      "httpGet": {
+                        "path": "/", 
+                        "port": 8001,
+                      }
+                    },
                 }
             }
         },
       }, // deployUi
 
+      uiIngress:: {
+          "apiVersion": "extensions/v1beta1", 
+          "kind": "Ingress", 
+          "metadata": {
+            "name": "argo-ui",
+            "namespace": namespace,
+          }, 
+          "annotations": {
+            "kubernetes.io/ingress.global-static-ip-name": "argo-ui",
+          },
+          "spec": {
+            "rules": [
+              {
+                "http": {
+                  "paths": [
+                     {
+                      "backend": {
+                        "serviceName": "argo-ui",
+                        "servicePort": 80,
+                      }, 
+                      "path": "/*"
+                    },
+                  ]
+                }
+              }
+            ],
+          }
+      }, // ingress
+      
       uiService: {
         "apiVersion": "v1", 
         "kind": "Service", 
@@ -198,8 +233,7 @@
             "app": "argo-ui"
           }, 
           "sessionAffinity": "None", 
-          # TODO(jlewi): Add an option to provision a load balancer?
-          # "type": "LoadBalancer"
+          "type": "NodePort",
         }
       },
 


### PR DESCRIPTION
* We use Argo to run our E2E tests so the UI is very useful for debugging tests.
* Add an ingress with a static IP to expose it publicly.

* Fix #131 